### PR TITLE
Prefill rz_owner_confirm from URL and improve NetBox lookup (owner mapping + override)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -52,6 +52,13 @@
       .replace(/'/g, '&#39;');
   };
 
+
+  C5.getUrlParam = function (name) {
+    var value = new URLSearchParams(window.location.search).get(name);
+    if (value === null || value === '') return null;
+    return value;
+  };
+
   // ── Spinner helpers ──
   // Shows a spinner inside the .field-group of the given element.
   C5.showSpinner = function (el, label) {
@@ -110,6 +117,14 @@
     form.querySelectorAll('input[type="date"]').forEach(function (input) {
       if (!input.value) input.value = todayStr;
     });
+
+    var eventType = form.getAttribute('data-event-type') || form.getAttribute('data-event') || '';
+    var assetIdParam = C5.getUrlParam('asset_id');
+    if (eventType === 'rz_owner_confirm' && assetIdParam) {
+      var assetIdInput = form.querySelector('[name="asset_id"]');
+      if (assetIdInput) assetIdInput.value = assetIdParam;
+      C5.performAssetLookup(assetIdParam, form, { forceOverride: true });
+    }
 
     // Update conditional required on change
     form.addEventListener('change', function () {

--- a/public/js/c5-asset-lookup.js
+++ b/public/js/c5-asset-lookup.js
@@ -66,7 +66,7 @@
    * befüllt werden (Fixes 3-A.2).
    */
   var NETBOX_CUSTOM_FIELD_MAP = {
-    asset_owner:    '#asset_owner, #owner_approval',
+    asset_owner:    '#asset_owner, #owner_approval, #owner',
     service:        '#service',
     criticality:    '#criticality',
     admin_user:     '#admin_user',
@@ -86,6 +86,11 @@
   // Hält den AbortController des zuletzt gestarteten Asset-Lookups.
   // Bei einem neuen Aufruf wird der vorherige Request abgebrochen (3-B).
   var _pendingLookupAbort = null;
+
+  // Modul-Promises für initiale Dropdown-Loads. performAssetLookup kann darauf warten,
+  // damit programmatische Aufrufe (ohne blur-User-Flow) keine Rennbedingungen erzeugen.
+  var _tenantsPromise = Promise.resolve();
+  var _contactsPromise = Promise.resolve();
 
   // ── Location cascading dropdowns ──
 
@@ -258,11 +263,11 @@
 
   C5.loadTenants = function (form) {
     var sel = form.querySelector('#tenant_id');
-    if (!sel) return;
+    if (!sel) return Promise.resolve();
     sel.disabled = true;
     C5.showSpinner(sel);
     C5.beginLoad(form);
-    fetch(C5.apiBase + '/tenants')
+    _tenantsPromise = fetch(C5.apiBase + '/tenants')
       .then(C5.checkAuth)
       .then(function (r) { return r.json(); })
       .then(function (list) {
@@ -284,6 +289,8 @@
         C5.hideSpinner(sel);
         C5.endLoad(form);
       });
+
+    return _tenantsPromise;
   };
 
   C5.syncTenantName = function (form) {
@@ -300,13 +307,13 @@
     // querySelectorAll statt querySelector: alle passenden Kontakt-Dropdowns befüllen,
     // nicht nur das erste im DOM (3-A.3)
     var sels = form.querySelectorAll('#asset_owner, #owner_approval, #owner');
-    if (!sels.length) return;
+    if (!sels.length) return Promise.resolve();
     sels.forEach(function (sel) {
       sel.disabled = true;
       C5.showSpinner(sel);
     });
     C5.beginLoad(form);
-    fetch(C5.apiBase + '/contacts')
+    _contactsPromise = fetch(C5.apiBase + '/contacts')
       .then(C5.checkAuth)
       .then(function (r) { return r.json(); })
       .then(function (list) {
@@ -333,6 +340,8 @@
         });
         C5.endLoad(form);
       });
+
+    return _contactsPromise;
   };
 
   C5.syncContactId = function (form) {
@@ -404,7 +413,10 @@
 
   // ── Asset Lookup ──
 
-  C5.performAssetLookup = function (assetId, form) {
+  C5.performAssetLookup = function (assetId, form, options) {
+    options = options || {};
+    var forceOverride = options.forceOverride === true;
+
     if (!assetId || assetId.trim() === '') return;
 
     // Vorherigen Request abbrechen, falls noch aktiv (3-B)
@@ -438,68 +450,58 @@
           if (key === 'device_type') return; // wird nach dem Laden der Gerätetypen gesetzt
           if (LOCATION_KEYS[key]) return;    // wird kaskadiert nach _locationsPromise gesetzt
           var el = form.querySelector(NETBOX_FIELD_MAP[key]);
-          if (el && !el.value && data[key]) {
-            if (el.tagName === 'SELECT') {
-              setSelectValue(el, data[key]);
-            } else {
-              el.value = data[key];
-            }
-          }
+          setElementValue(el, data[key], forceOverride);
         });
 
         // Gerätetyp erst setzen, nachdem das Dropdown vollständig geladen ist
         if (data['device_type']) {
           (_deviceTypesPromises.get(form) || Promise.resolve()).then(function () {  // WeakMap statt DOM-Property (3-C.3)
             var el = form.querySelector(NETBOX_FIELD_MAP['device_type']);
-            if (el && !el.value) {
+            if (el && (forceOverride || !el.value)) {
               setSelectValue(el, data['device_type']);
               syncDeviceTypeId(form, el);
             }
           });
         }
 
-        C5.syncTenantName(form);
+        Promise.all([_tenantsPromise, _contactsPromise]).then(function () {
+          C5.syncTenantName(form);
 
-        // Region, Standortgruppe und Standort kaskadiert setzen, sobald Standortdaten geladen sind
-        if ((data.region_id || data.site_group_id || data.site_id) && form.querySelector('#region_id')) {
-          _locationsPromise.then(function () {  // Modul-Promise statt DOM-Property (3-C.2)
-            // 1. Region setzen
-            if (data.region_id) {
-              var regionSel = form.querySelector('#region_id');
-              if (regionSel && !regionSel.value) setSelectValue(regionSel, data.region_id);
-            }
-            // 2. Standortgruppe-Dropdown auf Region filtern, dann Wert setzen
-            C5.filterSiteGroups(form);
-            if (data.site_group_id) {
-              var groupSel = form.querySelector('#site_group_id');
-              if (groupSel && !groupSel.value) setSelectValue(groupSel, data.site_group_id);
-            }
-            // 3. Standort-Dropdown auf Gruppe filtern, dann Wert setzen
-            C5.filterSites(form);
-            if (data.site_id) {
-              var siteSel = form.querySelector('#site_id');
-              if (siteSel && !siteSel.value) setSelectValue(siteSel, data.site_id);
-            }
-            syncLocationNames(form);
-          });
-        }
-
-        if (data.custom_fields) {
-          // querySelectorAll statt querySelector: Comma-Selektoren in der Map können mehrere
-          // Elemente treffen (z. B. '#asset_owner, #owner_approval') – alle befüllen (3-A.2)
-          Object.keys(NETBOX_CUSTOM_FIELD_MAP).forEach(function (key) {
-            form.querySelectorAll(NETBOX_CUSTOM_FIELD_MAP[key]).forEach(function (el) {
-              if (!el.value && data.custom_fields[key]) {
-                if (el.tagName === 'SELECT') {
-                  setSelectValue(el, data.custom_fields[key]);
-                } else {
-                  el.value = data.custom_fields[key];
-                }
+          // Region, Standortgruppe und Standort kaskadiert setzen, sobald Standortdaten geladen sind
+          if ((data.region_id || data.site_group_id || data.site_id) && form.querySelector('#region_id')) {
+            _locationsPromise.then(function () {  // Modul-Promise statt DOM-Property (3-C.2)
+              // 1. Region setzen
+              if (data.region_id) {
+                var regionSel = form.querySelector('#region_id');
+                if (regionSel && (forceOverride || !regionSel.value)) setSelectValue(regionSel, data.region_id);
               }
+              // 2. Standortgruppe-Dropdown auf Region filtern, dann Wert setzen
+              C5.filterSiteGroups(form);
+              if (data.site_group_id) {
+                var groupSel = form.querySelector('#site_group_id');
+                if (groupSel && (forceOverride || !groupSel.value)) setSelectValue(groupSel, data.site_group_id);
+              }
+              // 3. Standort-Dropdown auf Gruppe filtern, dann Wert setzen
+              C5.filterSites(form);
+              if (data.site_id) {
+                var siteSel = form.querySelector('#site_id');
+                if (siteSel && (forceOverride || !siteSel.value)) setSelectValue(siteSel, data.site_id);
+              }
+              syncLocationNames(form);
             });
-          });
-          C5.syncContactId(form);
-        }
+          }
+
+          if (data.custom_fields) {
+            // querySelectorAll statt querySelector: Comma-Selektoren in der Map können mehrere
+            // Elemente treffen (z. B. '#asset_owner, #owner_approval') – alle befüllen (3-A.2)
+            Object.keys(NETBOX_CUSTOM_FIELD_MAP).forEach(function (key) {
+              form.querySelectorAll(NETBOX_CUSTOM_FIELD_MAP[key]).forEach(function (el) {
+                setElementValue(el, data.custom_fields[key], forceOverride);
+              });
+            });
+            C5.syncContactId(form);
+          }
+        });
 
         showNetBoxBadge(form, data.status);
       })
@@ -524,6 +526,16 @@
         return;
       }
     }
+  }
+
+  function setElementValue(el, value, forceOverride) {
+    if (!el || !value) return;
+    if (!forceOverride && el.value) return;
+    if (el.tagName === 'SELECT') {
+      setSelectValue(el, value);
+      return;
+    }
+    el.value = value;
   }
 
   function showNetBoxBadge(form, status) {

--- a/public/js/c5-asset-lookup.js
+++ b/public/js/c5-asset-lookup.js
@@ -446,9 +446,12 @@
 
         // Einfache Felder direkt setzen (Standortfelder werden kaskadiert nach dem Location-Load gesetzt)
         var LOCATION_KEYS = { region_id: true, site_group_id: true, site_id: true };
+        // tenant_id muss auf _tenantsPromise warten, da das Dropdown async befüllt wird
+        var ASYNC_DROPDOWN_KEYS = { tenant_id: true };
         Object.keys(NETBOX_FIELD_MAP).forEach(function (key) {
           if (key === 'device_type') return; // wird nach dem Laden der Gerätetypen gesetzt
           if (LOCATION_KEYS[key]) return;    // wird kaskadiert nach _locationsPromise gesetzt
+          if (ASYNC_DROPDOWN_KEYS[key]) return; // wird nach _tenantsPromise gesetzt
           var el = form.querySelector(NETBOX_FIELD_MAP[key]);
           setElementValue(el, data[key], forceOverride);
         });
@@ -465,6 +468,11 @@
         }
 
         Promise.all([_tenantsPromise, _contactsPromise]).then(function () {
+          // tenant_id erst hier setzen, nachdem das Tenant-Dropdown geladen ist
+          if (data.tenant_id !== undefined) {
+            var tenantEl = form.querySelector(NETBOX_FIELD_MAP['tenant_id']);
+            setElementValue(tenantEl, data.tenant_id, forceOverride);
+          }
           C5.syncTenantName(form);
 
           // Region, Standortgruppe und Standort kaskadiert setzen, sobald Standortdaten geladen sind

--- a/templates/form_base.html.twig
+++ b/templates/form_base.html.twig
@@ -15,7 +15,7 @@
     </div>
   </div>
 
-  <form id="evidence-form" data-event="{{ event_type }}" novalidate>
+  <form id="evidence-form" data-event="{{ event_type }}" data-event-type="{{ event_type }}" novalidate>
     {% block form_fields %}{% endblock %}
 
     <div class="form-actions">

--- a/tests/Integration/Controller/FormControllerTest.php
+++ b/tests/Integration/Controller/FormControllerTest.php
@@ -72,7 +72,26 @@ class FormControllerTest extends AuthenticatedWebTestCase
         $crawler = $client->request('GET', '/forms/rz-owner-confirm?asset_id=SRV-001');
 
         $this->assertResponseIsSuccessful();
-        $this->assertCount(1, $crawler->filter('#evidence-form'));
+        $form = $crawler->filter('#evidence-form');
+        $this->assertCount(1, $form);
+        $this->assertEquals('rz_owner_confirm', $form->attr('data-event-type'));
+    }
+
+    /**
+     * @dataProvider formSlugProvider
+     */
+    public function testAllFormsHaveDataEventTypeAttribute(string $slug, string $expectedTitle): void
+    {
+        $client = static::createAuthenticatedClient();
+        $crawler = $client->request('GET', '/forms/' . $slug);
+
+        $this->assertResponseIsSuccessful();
+        $form = $crawler->filter('#evidence-form');
+        $this->assertCount(1, $form);
+        $this->assertNotEmpty(
+            $form->attr('data-event-type'),
+            sprintf('data-event-type sollte für Formular "%s" gesetzt sein', $slug)
+        );
     }
 
     public function testFormPageHasFormStatusDiv(): void

--- a/tests/Integration/Controller/FormControllerTest.php
+++ b/tests/Integration/Controller/FormControllerTest.php
@@ -61,6 +61,18 @@ class FormControllerTest extends AuthenticatedWebTestCase
         $form = $crawler->filter('#evidence-form');
         $this->assertCount(1, $form);
         $this->assertEquals('rz_provision', $form->attr('data-event'));
+        $this->assertEquals('rz_provision', $form->attr('data-event-type'));
+    }
+
+
+
+    public function testOwnerConfirmFormRendersWithAssetIdQueryParameter(): void
+    {
+        $client = static::createAuthenticatedClient();
+        $crawler = $client->request('GET', '/forms/rz-owner-confirm?asset_id=SRV-001');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('#evidence-form'));
     }
 
     public function testFormPageHasFormStatusDiv(): void

--- a/tests/js/app.test.js
+++ b/tests/js/app.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+function setupBaseC5() {
+  window.C5 = {
+    loadLabelsFromApi: vi.fn(),
+    evaluateConditionalRequired: vi.fn(),
+    loadTenants: vi.fn(),
+    loadContacts: vi.fn(),
+    loadLocations: vi.fn(),
+    loadDeviceTypes: vi.fn(),
+    filterSiteGroups: vi.fn(),
+    filterSites: vi.fn(),
+    syncTenantName: vi.fn(),
+    syncContactId: vi.fn(),
+    performAssetLookup: vi.fn(),
+    validateForm: vi.fn().mockReturnValue(false),
+    submitForm: vi.fn(),
+  }
+}
+
+async function importApp() {
+  vi.resetModules()
+  await import('../../public/js/app.js')
+}
+
+function buildForm(eventType = 'rz_owner_confirm') {
+  document.body.innerHTML = `
+    <form id="evidence-form" data-event-type="${eventType}" data-event="${eventType}">
+      <div class="field-group"><input name="asset_id" type="text"></div>
+      <button class="btn-submit" type="submit">Senden</button>
+    </form>
+  `
+  return document.getElementById('evidence-form')
+}
+
+describe('C5.getUrlParam', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    setupBaseC5()
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm')
+  })
+
+  it('liefert vorhandenen Parameter', async () => {
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm?asset_id=SRV-001')
+    await importApp()
+
+    expect(window.C5.getUrlParam('asset_id')).toBe('SRV-001')
+  })
+
+  it('normalisiert leeren Parameter auf null', async () => {
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm?asset_id=')
+    await importApp()
+
+    expect(window.C5.getUrlParam('asset_id')).toBeNull()
+  })
+
+  it('liefert null bei fehlendem Parameter', async () => {
+    await importApp()
+
+    expect(window.C5.getUrlParam('asset_id')).toBeNull()
+  })
+
+  it('decodiert URL-Encoding korrekt', async () => {
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm?asset_id=SRV%2F001%20A')
+    await importApp()
+
+    expect(window.C5.getUrlParam('asset_id')).toBe('SRV/001 A')
+  })
+})
+
+describe('DOMContentLoaded prefill für rz_owner_confirm', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    setupBaseC5()
+  })
+
+  it('ruft performAssetLookup bei rz_owner_confirm + asset_id auf', async () => {
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm?asset_id=SRV-001')
+    const form = buildForm('rz_owner_confirm')
+    await importApp()
+
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    expect(form.querySelector('[name="asset_id"]').value).toBe('SRV-001')
+    expect(window.C5.performAssetLookup).toHaveBeenCalledWith('SRV-001', form, { forceOverride: true })
+  })
+
+  it('ruft performAssetLookup nicht für andere event types auf', async () => {
+    window.history.replaceState({}, '', '/forms/rz-provision?asset_id=SRV-001')
+    buildForm('rz_provision')
+    await importApp()
+
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    expect(window.C5.performAssetLookup).not.toHaveBeenCalled()
+  })
+
+  it('ruft performAssetLookup nicht bei leerem asset_id auf', async () => {
+    window.history.replaceState({}, '', '/forms/rz-owner-confirm?asset_id=')
+    buildForm('rz_owner_confirm')
+    await importApp()
+
+    document.dispatchEvent(new Event('DOMContentLoaded'))
+
+    expect(window.C5.performAssetLookup).not.toHaveBeenCalled()
+  })
+})

--- a/tests/js/c5-asset-lookup-flow.test.js
+++ b/tests/js/c5-asset-lookup-flow.test.js
@@ -636,4 +636,190 @@ describe('performAssetLookup – rz_owner_confirm prefill', () => {
     })
     expect(form.querySelector('#tenant_name').value).toBe('Tenant A')
   })
+
+  it('setzt #owner korrekt wenn loadContacts noch nicht abgeschlossen war (Race-Condition)', async () => {
+    // Regressionstest: performAssetLookup wurde vor loadContacts gestartet (analog zum
+    // Tenants-Race-Condition-Test). Das Owner-Dropdown war beim NetBox-Response noch leer.
+    const form = makeAssetLookupForm(`
+      <div class="field-group"><select id="owner"><option value=""></option></select></div>
+      <input id="contact_id" type="hidden" />
+    `)
+
+    // fetch-Mock: /contacts → Alice, /asset-lookup → found mit asset_owner: 'Alice'
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/contacts')) {
+        return Promise.resolve(makeJsonResponse([{ id: 1, name: 'Alice' }]))
+      }
+      return Promise.resolve(makeJsonResponse({
+        found: true,
+        status: 'active',
+        custom_fields: { asset_owner: 'Alice' },
+      }))
+    })
+
+    // Reihenfolge wie in app.js: erst performAssetLookup, dann loadContacts
+    C5.performAssetLookup('SRV-001', form, { forceOverride: true })
+    C5.loadContacts(form)
+
+    await vi.waitFor(() => {
+      expect(form.querySelector('#owner').value).toBe('Alice')
+    })
+  })
+})
+
+
+describe('performAssetLookup – forceOverride für Location-Felder', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('überschreibt region_id, site_group_id und site_id bei forceOverride=true', async () => {
+    const form = makeForm(`
+      <div class="field-group"><input name="asset_id" type="text" /></div>
+      <div class="field-group">
+        <select id="region_id">
+          <option value=""></option>
+          <option value="1" selected>Region Nord</option>
+          <option value="2">Region Süd</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <select id="site_group_id">
+          <option value=""></option>
+          <option value="10" selected>Gruppe A</option>
+          <option value="11">Gruppe B</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <select id="site_id">
+          <option value=""></option>
+          <option value="100" selected>Site Alpha</option>
+          <option value="101">Site Beta</option>
+        </select>
+      </div>
+      <input id="region_name"     type="hidden" />
+      <input id="site_group_name" type="hidden" />
+      <input id="site_name"       type="hidden" />
+      <input id="contact_id"      type="hidden" />
+    `)
+
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({
+      found: true,
+      status: 'active',
+      region_id: '2',
+      site_group_id: '11',
+      site_id: '101',
+    }))
+
+    C5.performAssetLookup('SRV-001', form, { forceOverride: true })
+
+    await vi.waitFor(() => {
+      expect(form.querySelector('#region_id').value).toBe('2')
+    })
+    expect(form.querySelector('#site_group_id').value).toBe('11')
+    expect(form.querySelector('#site_id').value).toBe('101')
+  })
+
+  it('behält region_id, site_group_id und site_id ohne forceOverride', async () => {
+    const form = makeForm(`
+      <div class="field-group"><input name="asset_id" type="text" /></div>
+      <div class="field-group">
+        <select id="region_id">
+          <option value=""></option>
+          <option value="1" selected>Region Nord</option>
+          <option value="2">Region Süd</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <select id="site_group_id">
+          <option value=""></option>
+          <option value="10" selected>Gruppe A</option>
+          <option value="11">Gruppe B</option>
+        </select>
+      </div>
+      <div class="field-group">
+        <select id="site_id">
+          <option value=""></option>
+          <option value="100" selected>Site Alpha</option>
+          <option value="101">Site Beta</option>
+        </select>
+      </div>
+      <input id="region_name"     type="hidden" />
+      <input id="site_group_name" type="hidden" />
+      <input id="site_name"       type="hidden" />
+      <input id="contact_id"      type="hidden" />
+    `)
+
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({
+      found: true,
+      status: 'active',
+      region_id: '2',
+      site_group_id: '11',
+      site_id: '101',
+    }))
+
+    // Warte auf das Ende des asset-lookup-Requests (Fetch wurde aufgerufen)
+    C5.performAssetLookup('SRV-001', form)
+
+    await vi.waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled()
+    })
+    // Ein Tick abwarten, damit der Promise-Handler laufen kann
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Bestehende Werte müssen unverändert bleiben
+    expect(form.querySelector('#region_id').value).toBe('1')
+    expect(form.querySelector('#site_group_id').value).toBe('10')
+    expect(form.querySelector('#site_id').value).toBe('100')
+  })
+})
+
+
+describe('loadTenants / loadContacts – Promise-Rückgabe', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('loadTenants gibt ein Promise zurück wenn #tenant_id vorhanden ist', () => {
+    const form = makeForm(`
+      <div class="field-group"><select id="tenant_id"><option value=""></option></select></div>
+      <input id="tenant_name" type="hidden" />
+    `)
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse([]))
+
+    const result = C5.loadTenants(form)
+
+    expect(result).toBeInstanceOf(Promise)
+  })
+
+  it('loadTenants gibt einen aufgelösten Promise zurück wenn kein #tenant_id vorhanden ist', async () => {
+    const form = makeForm('')
+
+    const result = C5.loadTenants(form)
+
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  it('loadContacts gibt ein Promise zurück wenn #owner vorhanden ist', () => {
+    const form = makeForm(`
+      <div class="field-group"><select id="owner"><option value=""></option></select></div>
+      <input id="contact_id" type="hidden" />
+    `)
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse([]))
+
+    const result = C5.loadContacts(form)
+
+    expect(result).toBeInstanceOf(Promise)
+  })
+
+  it('loadContacts gibt einen aufgelösten Promise zurück wenn keine Kontakt-Selects vorhanden sind', async () => {
+    const form = makeForm('')
+
+    const result = C5.loadContacts(form)
+
+    expect(result).toBeInstanceOf(Promise)
+    await expect(result).resolves.toBeUndefined()
+  })
 })

--- a/tests/js/c5-asset-lookup-flow.test.js
+++ b/tests/js/c5-asset-lookup-flow.test.js
@@ -561,3 +561,48 @@ describe('performAssetLookup – 3-B: AbortController', () => {
     })
   })
 })
+
+
+describe('performAssetLookup – rz_owner_confirm prefill', () => {
+  it('befüllt #owner über custom_fields.asset_owner', async () => {
+    const form = makeAssetLookupForm(`
+      <div class="field-group"><select id="owner"><option value=""></option><option value="Alice">Alice</option></select></div>
+      <input id="contact_id" type="hidden" />
+    `)
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({
+      found: true,
+      status: 'active',
+      custom_fields: { asset_owner: 'Alice' },
+    }))
+
+    C5.performAssetLookup('SRV-001', form)
+    await vi.waitFor(() => {
+      expect(form.querySelector('#owner').value).toBe('Alice')
+    })
+  })
+
+  it('überschreibt Werte bei forceOverride=true', async () => {
+    const form = makeAssetLookupForm(`
+      <div class="field-group"><input id="serial_number" type="text" value="ALT" /></div>
+      <div class="field-group"><select id="owner"><option value=""></option><option value="Alice">Alice</option><option value="Bob" selected>Bob</option></select></div>
+      <div class="field-group"><select id="tenant_id"><option value=""></option><option value="55">Tenant A</option></select></div>
+      <input id="tenant_name" type="hidden" />
+      <input id="contact_id" type="hidden" />
+    `)
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({
+      found: true,
+      status: 'active',
+      serial_number: 'NEU',
+      tenant_id: '55',
+      custom_fields: { asset_owner: 'Alice' },
+    }))
+
+    C5.performAssetLookup('SRV-001', form, { forceOverride: true })
+    await vi.waitFor(() => {
+      expect(form.querySelector('#serial_number').value).toBe('NEU')
+    })
+
+    expect(form.querySelector('#owner').value).toBe('Alice')
+    expect(form.querySelector('#tenant_id').value).toBe('55')
+  })
+})

--- a/tests/js/c5-asset-lookup-flow.test.js
+++ b/tests/js/c5-asset-lookup-flow.test.js
@@ -605,4 +605,35 @@ describe('performAssetLookup – rz_owner_confirm prefill', () => {
     expect(form.querySelector('#owner').value).toBe('Alice')
     expect(form.querySelector('#tenant_id').value).toBe('55')
   })
+
+  it('setzt tenant_id korrekt wenn loadTenants noch nicht abgeschlossen war (Race-Condition)', async () => {
+    // Regressionstest: performAssetLookup wurde vor loadTenants gestartet (wie in app.js),
+    // das Tenant-Dropdown war beim NetBox-Response noch leer.
+    const form = makeAssetLookupForm(`
+      <div class="field-group"><select id="tenant_id"><option value=""></option></select></div>
+      <input id="tenant_name" type="hidden" />
+      <input id="contact_id" type="hidden" />
+    `)
+
+    // fetch-Mock: /tenants → Option 55, /asset-lookup → found mit tenant_id: '55'
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (url.includes('/tenants')) {
+        return Promise.resolve(makeJsonResponse([{ id: 55, name: 'Tenant A' }]))
+      }
+      return Promise.resolve(makeJsonResponse({
+        found: true,
+        status: 'active',
+        tenant_id: '55',
+      }))
+    })
+
+    // Reihenfolge wie in app.js: erst performAssetLookup, dann loadTenants
+    C5.performAssetLookup('SRV-001', form, { forceOverride: true })
+    C5.loadTenants(form)
+
+    await vi.waitFor(() => {
+      expect(form.querySelector('#tenant_id').value).toBe('55')
+    })
+    expect(form.querySelector('#tenant_name').value).toBe('Tenant A')
+  })
 })


### PR DESCRIPTION
### Motivation
- Allow the rz_owner_confirm form to be pre-filled from an `asset_id` URL parameter and reliably populate the owner field (`#owner`) as required by the spec. 
- Prevent race conditions when performing a programmatic lookup (client-side prefill) and enable explicit override of existing field values coming from a URL-driven workflow. 

### Description
- Extended `NETBOX_CUSTOM_FIELD_MAP` in `public/js/c5-asset-lookup.js` to include `#owner` for `custom_fields.asset_owner` so owner mappings fill `#owner` as well as `#asset_owner/#owner_approval`.
- Added `forceOverride` option to `C5.performAssetLookup(assetId, form, options)` and introduced `setElementValue` helper so URL-triggered lookups can overwrite existing values when requested.
- Made `loadTenants` and `loadContacts` return Promises and stored them as module-level promises (`_tenantsPromise`, `_contactsPromise`), and updated `performAssetLookup` to wait for these promises (plus location promise) before running dependent sync/prefill logic to avoid race conditions.
- Added `C5.getUrlParam(name)` helper and DOMContentLoaded prefill logic in `public/js/app.js` that reads `asset_id` and, when `data-event-type === 'rz_owner_confirm'`, sets the `asset_id` input and calls `C5.performAssetLookup(..., { forceOverride: true })`.
- Ensured the base form template includes `data-event-type="{{ event_type }}` in `templates/form_base.html.twig` so the prefill logic can be gated by event type.
- Added JS unit tests: `tests/js/app.test.js` (URL param parsing and DOMContentLoaded prefill gating) and extended `tests/js/c5-asset-lookup-flow.test.js` with checks for `#owner` mapping and `forceOverride` behavior.
- Added an integration smoke assertion to `tests/Integration/Controller/FormControllerTest.php` that a GET with `?asset_id=...` renders the form and to ensure `data-event-type` is present.

### Testing
- Ran `npm install` successfully to install test deps in the environment.
- Ran `npm run test:js` (Vitest) and all JS tests passed: 54 tests, 54 passed (`tests/js/c5-asset-lookup-guards.test.js`, `tests/js/app.test.js`, `tests/js/c5-asset-lookup-flow.test.js`).
- Linted the new integration test with `php -l tests/Integration/Controller/FormControllerTest.php` which reported no syntax errors.
- Attempted to run PHPUnit via `vendor/bin/phpunit tests/Integration/Controller/FormControllerTest.php` but the PHPUnit binary is not available in this environment, so integration test execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6635831208331af81814dee3d20c9)