### PR TITLE
Browser-Caching für JavaScript im Dev-Modus deaktivieren

### DIFF
--- a/templates/form_base.html.twig
+++ b/templates/form_base.html.twig
@@ -39,11 +39,14 @@
     6. app.js             – C5.apiBase, C5.checkAuth, C5.show/hideSpinner,
                             C5.begin/endLoad; DOMContentLoaded-Init
   ACHTUNG: Reihenfolge nicht ändern ohne c5-asset-lookup.js-Header zu aktualisieren!
+
+  Im DEV-Modus hängen wir einen Cache-Buster an, damit Browser-JS nicht gecached wird.
 #}
-<script src="{{ asset('js/c5-labels.js') }}"></script>
-<script src="{{ asset('js/c5-validation.js') }}"></script>
-<script src="{{ asset('js/c5-asset-lookup.js') }}"></script>
-<script src="{{ asset('js/c5-submit.js') }}"></script>
-<script src="{{ asset('js/c5-summary.js') }}"></script>
-<script src="{{ asset('js/app.js') }}"></script>
+{% set js_cache_bust = app.environment == 'dev' ? ('?v=' ~ 'now'|date('U')) : '' %}
+<script src="{{ asset('js/c5-labels.js') ~ js_cache_bust }}"></script>
+<script src="{{ asset('js/c5-validation.js') ~ js_cache_bust }}"></script>
+<script src="{{ asset('js/c5-asset-lookup.js') ~ js_cache_bust }}"></script>
+<script src="{{ asset('js/c5-submit.js') ~ js_cache_bust }}"></script>
+<script src="{{ asset('js/c5-summary.js') ~ js_cache_bust }}"></script>
+<script src="{{ asset('js/app.js') ~ js_cache_bust }}"></script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Browser cache lädt lokale JS-Dateien während der Entwicklung häufig weiter, was das Testen aktueller Änderungen erschwert.
- Ziel ist es, im Entwicklungsmodus das Caching für eingebundene Skripte zu unterbinden, ohne das Produktionsverhalten zu verändern.

### Description
- Füge in `templates/form_base.html.twig` eine Template-Variable `js_cache_bust` hinzu, die `'?v=<unix-timestamp>'` liefert, wenn `app.environment == 'dev'`, ansonsten leer bleibt.
- Hänge `js_cache_bust` an alle `<script src="{{ asset(...) }}`-Includes an, damit Browser im Dev-Modus eine neue URL sehen und die Dateien neu laden.
- Ergänze den Kommentarblock über den Script-Includes um einen Hinweis zur Cache-Busting-Absicht.

### Testing
- Ausgeführt: `git diff --check`, Ergebnis: erfolgreich.
- Ausgeführt: `git status --short`, Ergebnis: zeigt die modifizierte Template-Datei an.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66b4c10e883319690d03d63850d83)