### PR TITLE
Add comprehensive E2E test suite for Evidence forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ Thumbs.db
 
 # Docker
 docker-compose.override.yml
+
+# E2E Tests
+tests/e2e/node_modules/
+tests/e2e/package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: help setup build up down restart logs status clean test stan lint lint-fix coverage migrate
+.PHONY: help setup build up down restart logs status clean test stan lint lint-fix coverage migrate test-e2e
 
 COMPOSE = docker compose
+COMPOSE_E2E = $(COMPOSE) -f docker-compose.yml -f docker-compose.e2e.yml
 # compute absolute path once (avoid tricky escaping of $$(pwd))
 PWD := $(shell pwd)
 # helper image for running arbitrary PHP commands on the host tree
@@ -75,6 +76,12 @@ phpmd: ## PHP Mess Detector (phpmd) ausfuehren
 
 coverage: ## PHPUnit mit Coverage-Report
 	$(PHP) php -dpcov.enabled=1 vendor/bin/phpunit --coverage-html=var/coverage --colors=always
+
+test-e2e: ## E2E-Tests mit TestCafe ausfuehren (startet App + Mailpit automatisch)
+	$(COMPOSE_E2E) build testcafe
+	$(COMPOSE_E2E) run --rm testcafe
+	@echo ""
+	@echo "E2E-Tests abgeschlossen."
 
 clean: ## Container, Images und Volumes entfernen
 	$(COMPOSE) down -v --rmi local

--- a/config/c5_evidence.e2e.yaml
+++ b/config/c5_evidence.e2e.yaml
@@ -1,0 +1,59 @@
+# C5 Evidence Tool – E2E-Testkonfiguration
+# Jira und NetBox deaktiviert, SMTP via Mailpit.
+
+smtp:
+  host: "mailpit"
+  port: 1025
+  encryption: "none"
+  username: ""
+  password: ""
+  from_address: "c5-evidence@company.de"
+  from_name: "C5 Evidence Tool"
+
+evidence:
+  rz_assets:
+    to: "rz-evidence@company.de"
+    cc: []
+  admin_devices:
+    to: "privileged-evidence@company.de"
+    cc:
+      - "it-security@company.de"
+
+jira:
+  enabled: false
+  base_url: "https://jira.example.de"
+  project_key: "ITOPS"
+  issue_type: "Task"
+  api_token: "DISABLED_FOR_E2E"
+
+jira_rules:
+  rz_provision: "none"
+  rz_retire: "none"
+  rz_owner_confirm: "none"
+  admin_provision: "none"
+  admin_user_commitment: "none"
+  admin_return: "none"
+  admin_access_cleanup: "none"
+
+netbox:
+  enabled: false
+  base_url: "https://netbox.example.de"
+  api_token: "DISABLED_FOR_E2E"
+  timeout: 5
+  verify_ssl: false
+  debug: false
+  contact_role_owner: "owner"
+  on_error: "warn"
+  sync_rules:
+    rz_provision: "none"
+    rz_retire: "none"
+    rz_owner_confirm: "none"
+    admin_provision: "none"
+    admin_user_commitment: "none"
+    admin_return: "none"
+    admin_access_cleanup: "none"
+  create_on_provision: false
+  provision_defaults:
+    device_type_id: 1
+    site_id: 1
+    role_id: 1

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,34 @@
+# Docker Compose Override fuer E2E-Tests
+# Verwendung: docker compose -f docker-compose.yml -f docker-compose.e2e.yml run --rm testcafe
+
+services:
+  app:
+    volumes:
+      - ./config/c5_evidence.e2e.yaml:/app/config/c5_evidence.yaml:ro
+
+  mailpit:
+    image: axllent/mailpit:latest
+    restart: unless-stopped
+    profiles: []
+
+  testcafe:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.testcafe
+    volumes:
+      - ./tests/e2e:/e2e
+      - /e2e/node_modules
+    command:
+      - "chromium:headless --no-sandbox --disable-gpu"
+      - "/e2e/tests/"
+      - "--reporter"
+      - "spec"
+    environment:
+      - BASE_URL=http://web:80
+    depends_on:
+      app:
+        condition: service_healthy
+      web:
+        condition: service_started
+      mailpit:
+        condition: service_started

--- a/docker/Dockerfile.testcafe
+++ b/docker/Dockerfile.testcafe
@@ -1,0 +1,21 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       chromium \
+       fonts-liberation \
+       libatk-bridge2.0-0 \
+       libgtk-3-0 \
+       libnss3 \
+       libxss1 \
+       libgbm1 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CHROMIUM_PATH=/usr/bin/chromium
+
+WORKDIR /e2e
+
+COPY tests/e2e/package.json tests/e2e/package-lock.json* ./
+RUN npm install
+
+ENTRYPOINT ["npx", "testcafe"]

--- a/tests/e2e/.testcaferc.js
+++ b/tests/e2e/.testcaferc.js
@@ -1,0 +1,13 @@
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+module.exports = {
+    baseUrl: BASE_URL,
+    browsers: ['chromium:headless --no-sandbox --disable-gpu'],
+    src: ['tests/'],
+    reporter: 'spec',
+    selectorTimeout: 10000,
+    assertionTimeout: 10000,
+    pageLoadTimeout: 15000,
+    ajaxRequestTimeout: 30000,
+    pageRequestTimeout: 30000,
+};

--- a/tests/e2e/fixtures/admin-access-cleanup.json
+++ b/tests/e2e/fixtures/admin-access-cleanup.json
@@ -1,0 +1,13 @@
+{
+  "slug": "admin-access-cleanup",
+  "eventType": "admin_access_cleanup",
+  "title": "Privileged Access Cleanup (IAM)",
+  "fields": {
+    "asset_id": { "type": "text", "value": "ADM-E2E-004" },
+    "admin_user": { "type": "text", "value": "m.mustermann@company.de" },
+    "cleanup_date": { "type": "date", "value": "2026-03-03" },
+    "account_removed": { "type": "checkbox" },
+    "keys_revoked": { "type": "checkbox" },
+    "device_wiped": { "type": "checkbox" }
+  }
+}

--- a/tests/e2e/fixtures/admin-provision.json
+++ b/tests/e2e/fixtures/admin-provision.json
@@ -1,0 +1,21 @@
+{
+  "slug": "admin-provision",
+  "eventType": "admin_provision",
+  "title": "Inbetriebnahme Admin-Endgerät",
+  "fields": {
+    "asset_id": { "type": "text", "value": "ADM-E2E-001" },
+    "device_type": { "type": "select", "value": "Admin Laptop" },
+    "manufacturer": { "type": "text", "value": "Lenovo" },
+    "model": { "type": "text", "value": "ThinkPad X1 Carbon" },
+    "serial_number": { "type": "text", "value": "SN-ADM-67890" },
+    "commission_date": { "type": "date", "value": "2026-03-03" },
+    "admin_user": { "type": "text", "value": "m.mustermann@company.de" },
+    "security_owner": { "type": "text", "value": "IT-Security Team" },
+    "purpose": { "type": "text", "value": "Firewall Admin" },
+    "disk_encryption": { "type": "checkbox" },
+    "mfa_active": { "type": "checkbox" },
+    "edr_active": { "type": "checkbox" },
+    "patch_process": { "type": "checkbox" },
+    "no_private_use": { "type": "checkbox" }
+  }
+}

--- a/tests/e2e/fixtures/admin-return.json
+++ b/tests/e2e/fixtures/admin-return.json
@@ -1,0 +1,13 @@
+{
+  "slug": "admin-return",
+  "eventType": "admin_return",
+  "title": "Rückgabe Admin-Endgerät",
+  "fields": {
+    "asset_id": { "type": "text", "value": "ADM-E2E-003" },
+    "admin_user": { "type": "text", "value": "m.mustermann@company.de" },
+    "return_date": { "type": "date", "value": "2026-03-03" },
+    "return_reason": { "type": "select", "value": "Rollenwechsel" },
+    "condition": { "type": "select", "value": "OK" },
+    "accessories_complete": { "type": "select", "value": "Ja" }
+  }
+}

--- a/tests/e2e/fixtures/admin-user-commitment.json
+++ b/tests/e2e/fixtures/admin-user-commitment.json
@@ -1,0 +1,15 @@
+{
+  "slug": "admin-user-commitment",
+  "eventType": "admin_user_commitment",
+  "title": "Verpflichtung Admin-User",
+  "fields": {
+    "asset_id": { "type": "text", "value": "ADM-E2E-002" },
+    "admin_user": { "type": "text", "value": "m.mustermann@company.de" },
+    "commitment_date": { "type": "date", "value": "2026-03-03" },
+    "admin_tasks_only": { "type": "checkbox" },
+    "no_mail_office": { "type": "checkbox" },
+    "no_credential_sharing": { "type": "checkbox" },
+    "report_loss": { "type": "checkbox" },
+    "return_on_change": { "type": "checkbox" }
+  }
+}

--- a/tests/e2e/fixtures/rz-owner-confirm.json
+++ b/tests/e2e/fixtures/rz-owner-confirm.json
@@ -1,0 +1,14 @@
+{
+  "slug": "rz-owner-confirm",
+  "eventType": "rz_owner_confirm",
+  "title": "Owner-Betriebsbestätigung",
+  "fields": {
+    "asset_id": { "type": "text", "value": "SRV-E2E-003" },
+    "owner": { "type": "contact_select", "value": "Max Mustermann" },
+    "confirm_date": { "type": "date", "value": "2026-03-03" },
+    "purpose_bound": { "type": "checkbox" },
+    "change_process": { "type": "checkbox" },
+    "admin_access_controlled": { "type": "checkbox" },
+    "lifecycle_managed": { "type": "checkbox" }
+  }
+}

--- a/tests/e2e/fixtures/rz-provision.json
+++ b/tests/e2e/fixtures/rz-provision.json
@@ -1,0 +1,21 @@
+{
+  "slug": "rz-provision",
+  "eventType": "rz_provision",
+  "title": "Inbetriebnahme RZ-Asset",
+  "fields": {
+    "asset_id": { "type": "text", "value": "SRV-E2E-001" },
+    "device_type": { "type": "select", "value": "Server" },
+    "manufacturer": { "type": "text", "value": "Dell" },
+    "model": { "type": "text", "value": "PowerEdge R750" },
+    "serial_number": { "type": "text", "value": "SN-E2E-12345" },
+    "location": { "type": "text", "value": "RZ Haan Rack B-12" },
+    "commission_date": { "type": "date", "value": "2026-03-03" },
+    "asset_owner": { "type": "contact_select", "value": "Max Mustermann" },
+    "service": { "type": "text", "value": "Plattform-Test" },
+    "criticality": { "type": "select", "value": "mittel" },
+    "change_ref": { "type": "text", "value": "CHG-E2E-001" },
+    "monitoring_active": { "type": "checkbox" },
+    "patch_process": { "type": "checkbox" },
+    "access_controlled": { "type": "checkbox" }
+  }
+}

--- a/tests/e2e/fixtures/rz-retire.json
+++ b/tests/e2e/fixtures/rz-retire.json
@@ -1,0 +1,14 @@
+{
+  "slug": "rz-retire",
+  "eventType": "rz_retire",
+  "title": "Außerbetriebnahme RZ-Asset",
+  "fields": {
+    "asset_id": { "type": "text", "value": "SRV-E2E-002" },
+    "retire_date": { "type": "date", "value": "2026-03-03" },
+    "reason": { "type": "select", "value": "EOL" },
+    "owner_approval": { "type": "contact_select", "value": "Max Mustermann" },
+    "followup": { "type": "select", "value": "Entsorgung" },
+    "data_handling": { "type": "radio", "value": "Secure Wipe" },
+    "data_handling_ref": { "type": "text", "value": "WIPE-CERT-2026-001" }
+  }
+}

--- a/tests/e2e/helpers/api-mocks.js
+++ b/tests/e2e/helpers/api-mocks.js
@@ -1,0 +1,43 @@
+import { RequestMock } from 'testcafe';
+
+/**
+ * Mock-Kontakte fuer contact_select Dropdowns
+ * (asset_owner, owner_approval, owner)
+ */
+const MOCK_CONTACTS = [
+    { id: 1, name: 'Max Mustermann' },
+    { id: 2, name: 'Erika Musterfrau' },
+    { id: 3, name: 'Hans Schmidt' },
+];
+
+/**
+ * Mock-Mandanten fuer tenant_select Dropdown
+ */
+const MOCK_TENANTS = [
+    { id: 10, name: 'Mandant A' },
+    { id: 20, name: 'Mandant B' },
+];
+
+/**
+ * RequestMock fuer alle API-Endpunkte die auf externe Services
+ * (NetBox) zugreifen. /api/submit wird NICHT gemockt – der echte
+ * Backend-Flow (inkl. Mailpit) wird getestet.
+ */
+const apiMocks = RequestMock()
+    .onRequestTo(/\/api\/contacts/)
+    .respond(JSON.stringify(MOCK_CONTACTS), 200, {
+        'content-type': 'application/json',
+        'access-control-allow-origin': '*',
+    })
+    .onRequestTo(/\/api\/tenants/)
+    .respond(JSON.stringify(MOCK_TENANTS), 200, {
+        'content-type': 'application/json',
+        'access-control-allow-origin': '*',
+    })
+    .onRequestTo(/\/api\/asset-lookup/)
+    .respond(JSON.stringify({ found: false }), 200, {
+        'content-type': 'application/json',
+        'access-control-allow-origin': '*',
+    });
+
+export { apiMocks, MOCK_CONTACTS, MOCK_TENANTS };

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "c5-evidence-e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "E2E-Tests fuer C5 Evidence Tool",
+  "scripts": {
+    "test": "testcafe"
+  },
+  "dependencies": {
+    "testcafe": "^3.7.2"
+  }
+}

--- a/tests/e2e/pages/form.page.js
+++ b/tests/e2e/pages/form.page.js
@@ -1,0 +1,144 @@
+import { Selector, t } from 'testcafe';
+
+/**
+ * Generischer Page Object fuer alle 7 Evidence-Formulare.
+ * Erkennt Feldtypen und befuellt sie automatisch aus Fixture-Daten.
+ */
+class FormPage {
+    constructor() {
+        this.form = Selector('#evidence-form');
+        this.submitBtn = Selector('.btn-submit');
+        this.formStatus = Selector('#form-status');
+        this.summaryOverlay = Selector('.summary-overlay');
+        this.summaryPanel = Selector('.summary-panel');
+        this.summaryTable = Selector('.summary-table');
+        this.summaryClose = Selector('.summary-panel .btn-secondary').withText('Schließen');
+        this.fieldErrors = Selector('.field-error');
+        this.fieldErrorMessages = Selector('.field-error-msg');
+        this.heading = Selector('h1');
+    }
+
+    /**
+     * Befuellt ein einzelnes Formularfeld anhand seines Typs.
+     *
+     * @param {string} name  - Feldname (HTML name-Attribut)
+     * @param {object} field - { type, value }
+     */
+    async fillField(name, field) {
+        switch (field.type) {
+            case 'text': {
+                const input = Selector(`input[name="${name}"]`);
+                await t.selectText(input).pressKey('delete').typeText(input, field.value);
+                break;
+            }
+            case 'date': {
+                const input = Selector(`input[name="${name}"]`);
+                // Date inputs are pre-filled with today; overwrite with fixture value
+                await t.selectText(input).pressKey('delete').typeText(input, field.value);
+                break;
+            }
+            case 'select': {
+                const select = Selector(`select[name="${name}"]`);
+                const option = select.find('option').withText(field.value);
+                await t.click(select).click(option);
+                break;
+            }
+            case 'checkbox': {
+                const checkbox = Selector(`input[name="${name}"][type="checkbox"]`);
+                const isChecked = await checkbox.checked;
+                if (!isChecked) {
+                    await t.click(checkbox);
+                }
+                break;
+            }
+            case 'radio': {
+                const radio = Selector(`input[name="${name}"][type="radio"][value="${field.value}"]`);
+                await t.click(radio);
+                break;
+            }
+            case 'contact_select': {
+                // Contact selects werden per API-Mock befuellt.
+                // Warten bis Optionen geladen sind, dann auswaehlen.
+                const select = Selector(`select[name="${name}"]`);
+                const option = select.find('option').withText(field.value);
+                await t.expect(option.exists).ok(`Kontakt-Option "${field.value}" nicht gefunden in ${name}`, { timeout: 5000 });
+                await t.click(select).click(option);
+                break;
+            }
+            default:
+                throw new Error(`Unbekannter Feldtyp: ${field.type} fuer Feld ${name}`);
+        }
+    }
+
+    /**
+     * Befuellt alle Felder aus einer Fixture-Definition.
+     *
+     * @param {object} fields - { feldname: { type, value }, ... }
+     */
+    async fillForm(fields) {
+        for (const [name, field] of Object.entries(fields)) {
+            await this.fillField(name, field);
+        }
+    }
+
+    /** Klickt den "Evidence senden"-Button */
+    async submit() {
+        await t.click(this.submitBtn);
+    }
+
+    /** Prueft ob die Erfolgsmeldung sichtbar ist */
+    async expectSuccess() {
+        await t
+            .expect(this.formStatus.visible).ok('Statusmeldung nicht sichtbar', { timeout: 15000 })
+            .expect(this.formStatus.hasClass('success')).ok('Statusmeldung ist kein Erfolg')
+            .expect(this.formStatus.textContent).contains('Evidence-Mail versendet');
+    }
+
+    /** Prueft ob das Summary-Overlay angezeigt wird */
+    async expectSummaryOverlay() {
+        await t
+            .expect(this.summaryOverlay.visible).ok('Summary-Overlay nicht sichtbar', { timeout: 5000 })
+            .expect(this.summaryPanel.find('h2').withText('Evidence-Zusammenfassung').visible).ok();
+    }
+
+    /** Prueft ob die Request-ID im Summary-Overlay vorhanden ist */
+    async expectRequestId() {
+        const infoText = await this.summaryPanel.find('p').textContent;
+        await t.expect(infoText).contains('Request-ID:');
+    }
+
+    /** Schliesst das Summary-Overlay */
+    async closeSummary() {
+        await t.click(this.summaryClose);
+        await t.expect(this.summaryOverlay.exists).notOk({ timeout: 3000 });
+    }
+
+    /** Prueft ob Validierungsfehler angezeigt werden */
+    async expectValidationErrors(minCount = 1) {
+        await t.expect(this.fieldErrors.count).gte(minCount, `Mindestens ${minCount} Validierungsfehler erwartet`);
+    }
+
+    /** Prueft ob KEINE Validierungsfehler angezeigt werden */
+    async expectNoValidationErrors() {
+        await t.expect(this.fieldErrors.count).eql(0, 'Keine Validierungsfehler erwartet');
+    }
+
+    /** Prueft ob ein bestimmtes Feld einen Fehler hat */
+    async expectFieldError(name) {
+        const fieldGroup = Selector(`[name="${name}"]`).parent('.field-group');
+        const fieldCheckbox = Selector(`[name="${name}"]`).parent('.field-checkbox');
+        const groupHasError = await fieldGroup.hasClass('field-error').catch(() => false);
+        const checkboxHasError = await fieldCheckbox.hasClass('field-error').catch(() => false);
+        await t.expect(groupHasError || checkboxHasError).ok(`Feld "${name}" sollte einen Fehler haben`);
+    }
+
+    /** Prueft ob ein bestimmtes Feld KEINEN Fehler hat */
+    async expectNoFieldError(name) {
+        const fieldGroup = Selector(`[name="${name}"]`).parent('.field-group');
+        if (await fieldGroup.exists) {
+            await t.expect(fieldGroup.hasClass('field-error')).notOk(`Feld "${name}" sollte keinen Fehler haben`);
+        }
+    }
+}
+
+export default new FormPage();

--- a/tests/e2e/pages/index.page.js
+++ b/tests/e2e/pages/index.page.js
@@ -1,0 +1,27 @@
+import { Selector } from 'testcafe';
+
+/** Page Object fuer die Startseite (/) */
+class IndexPage {
+    constructor() {
+        this.heading = Selector('h1').withText('Evidence erfassen');
+        this.trackA = Selector('.track-section.track-a');
+        this.trackB = Selector('.track-section.track-b');
+        this.formCards = Selector('.form-card');
+    }
+
+    /** Gibt die Formular-Karte mit dem passenden href-slug zurueck */
+    getCardBySlug(slug) {
+        return this.formCards.withAttribute('href', new RegExp(slug));
+    }
+
+    /** Gibt die Karten einer Track-Sektion zurueck */
+    getTrackACards() {
+        return this.trackA.find('.form-card');
+    }
+
+    getTrackBCards() {
+        return this.trackB.find('.form-card');
+    }
+}
+
+export default new IndexPage();

--- a/tests/e2e/tests/01-index.test.js
+++ b/tests/e2e/tests/01-index.test.js
@@ -1,0 +1,56 @@
+import indexPage from '../pages/index.page';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+fixture`Startseite`
+    .page`${BASE_URL}/`;
+
+test('Ueberschrift und Seitentitel werden angezeigt', async (t) => {
+    await t
+        .expect(indexPage.heading.visible).ok()
+        .expect(indexPage.heading.textContent).contains('Evidence erfassen');
+});
+
+test('Track A zeigt 3 Formular-Karten', async (t) => {
+    await t
+        .expect(indexPage.trackA.visible).ok()
+        .expect(indexPage.getTrackACards().count).eql(3);
+});
+
+test('Track B zeigt 4 Formular-Karten', async (t) => {
+    await t
+        .expect(indexPage.trackB.visible).ok()
+        .expect(indexPage.getTrackBCards().count).eql(4);
+});
+
+test('Insgesamt 7 Formular-Karten vorhanden', async (t) => {
+    await t.expect(indexPage.formCards.count).eql(7);
+});
+
+const expectedForms = [
+    { slug: 'rz-provision', title: 'Inbetriebnahme RZ-Asset' },
+    { slug: 'rz-retire', title: 'Außerbetriebnahme RZ-Asset' },
+    { slug: 'rz-owner-confirm', title: 'Owner-Betriebsbestätigung' },
+    { slug: 'admin-provision', title: 'Inbetriebnahme Admin-Endgerät' },
+    { slug: 'admin-user-commitment', title: 'Verpflichtung Admin-User' },
+    { slug: 'admin-return', title: 'Rückgabe Admin-Endgerät' },
+    { slug: 'admin-access-cleanup', title: 'Privileged Access Cleanup' },
+];
+
+for (const form of expectedForms) {
+    test(`Karte "${form.title}" ist vorhanden und verlinkt korrekt`, async (t) => {
+        const card = indexPage.getCardBySlug(form.slug);
+        await t
+            .expect(card.exists).ok(`Karte fuer ${form.slug} nicht gefunden`)
+            .expect(card.visible).ok();
+    });
+}
+
+for (const form of expectedForms) {
+    test(`Klick auf "${form.title}" oeffnet das Formular`, async (t) => {
+        const card = indexPage.getCardBySlug(form.slug);
+        await t
+            .click(card)
+            .expect(indexPage.heading.textContent).contains(form.title.split(' ')[0]);
+    });
+}

--- a/tests/e2e/tests/02-form-submit.test.js
+++ b/tests/e2e/tests/02-form-submit.test.js
@@ -1,0 +1,56 @@
+import { apiMocks } from '../helpers/api-mocks';
+import formPage from '../pages/form.page';
+
+import rzProvision from '../fixtures/rz-provision.json';
+import rzRetire from '../fixtures/rz-retire.json';
+import rzOwnerConfirm from '../fixtures/rz-owner-confirm.json';
+import adminProvision from '../fixtures/admin-provision.json';
+import adminUserCommitment from '../fixtures/admin-user-commitment.json';
+import adminReturn from '../fixtures/admin-return.json';
+import adminAccessCleanup from '../fixtures/admin-access-cleanup.json';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+const ALL_FIXTURES = [
+    rzProvision,
+    rzRetire,
+    rzOwnerConfirm,
+    adminProvision,
+    adminUserCommitment,
+    adminReturn,
+    adminAccessCleanup,
+];
+
+for (const fixtureData of ALL_FIXTURES) {
+    fixture`Formular-Submit: ${fixtureData.title}`
+        .page`${BASE_URL}/forms/${fixtureData.slug}`
+        .requestHooks(apiMocks);
+
+    test(`${fixtureData.title} – Formular wird korrekt geladen`, async (t) => {
+        await t
+            .expect(formPage.form.exists).ok()
+            .expect(formPage.heading.textContent).contains(fixtureData.title)
+            .expect(formPage.submitBtn.visible).ok();
+    });
+
+    test(`${fixtureData.title} – Happy Path: ausfuellen und absenden`, async (t) => {
+        // Kurz warten damit API-Mocks Dropdowns befuellen koennen
+        await t.wait(1000);
+
+        // Alle Felder aus Fixture ausfuellen
+        await formPage.fillForm(fixtureData.fields);
+
+        // Formular absenden
+        await formPage.submit();
+
+        // Erfolg pruefen
+        await formPage.expectSuccess();
+
+        // Summary-Overlay pruefen
+        await formPage.expectSummaryOverlay();
+        await formPage.expectRequestId();
+
+        // Overlay schliessen
+        await formPage.closeSummary();
+    });
+}

--- a/tests/e2e/tests/03-validation.test.js
+++ b/tests/e2e/tests/03-validation.test.js
@@ -1,0 +1,149 @@
+import { Selector } from 'testcafe';
+import { apiMocks } from '../helpers/api-mocks';
+import formPage from '../pages/form.page';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8080';
+
+// ── Leeres Formular: Pflichtfeld-Validierung ──
+
+fixture`Validierung: rz-provision leer absenden`
+    .page`${BASE_URL}/forms/rz-provision`
+    .requestHooks(apiMocks);
+
+test('Leeres RZ-Provision-Formular zeigt Pflichtfeld-Fehler', async (t) => {
+    // Date-Felder werden automatisch mit heute befuellt, daher leeren
+    const dateInput = Selector('input[name="commission_date"]');
+    await t.selectText(dateInput).pressKey('delete');
+
+    // Direkt absenden ohne Felder auszufuellen
+    await formPage.submit();
+
+    // Validierungsfehler muessen sichtbar sein
+    await formPage.expectValidationErrors(1);
+});
+
+fixture`Validierung: admin-provision leer absenden`
+    .page`${BASE_URL}/forms/admin-provision`
+    .requestHooks(apiMocks);
+
+test('Leeres Admin-Provision-Formular zeigt Pflichtfeld-Fehler', async (t) => {
+    const dateInput = Selector('input[name="commission_date"]');
+    await t.selectText(dateInput).pressKey('delete');
+
+    await formPage.submit();
+
+    await formPage.expectValidationErrors(1);
+});
+
+// ── Konditionale Validierung: rz_retire / data_handling_ref ──
+
+fixture`Validierung: rz-retire konditionale Felder`
+    .page`${BASE_URL}/forms/rz-retire`
+    .requestHooks(apiMocks);
+
+test('data_handling = "Secure Wipe" → data_handling_ref wird Pflichtfeld', async (t) => {
+    await t.wait(1000);
+
+    // Pflichtfelder ausfuellen
+    await formPage.fillField('asset_id', { type: 'text', value: 'SRV-VAL-001' });
+    await formPage.fillField('reason', { type: 'select', value: 'EOL' });
+    await formPage.fillField('owner_approval', { type: 'contact_select', value: 'Max Mustermann' });
+    await formPage.fillField('followup', { type: 'select', value: 'Entsorgung' });
+
+    // Radio "Secure Wipe" waehlen → data_handling_ref wird required
+    await formPage.fillField('data_handling', { type: 'radio', value: 'Secure Wipe' });
+
+    // Absenden OHNE data_handling_ref
+    await formPage.submit();
+
+    // Validierungsfehler fuer data_handling_ref erwartet
+    const refGroup = Selector('#data_handling_ref_group');
+    await t.expect(refGroup.hasClass('field-error')).ok(
+        'data_handling_ref sollte einen Fehler haben wenn data_handling != "Nicht relevant"'
+    );
+});
+
+test('data_handling = "Nicht relevant" → data_handling_ref ist nicht Pflicht', async (t) => {
+    await t.wait(1000);
+
+    // Pflichtfelder ausfuellen
+    await formPage.fillField('asset_id', { type: 'text', value: 'SRV-VAL-002' });
+    await formPage.fillField('reason', { type: 'select', value: 'EOL' });
+    await formPage.fillField('owner_approval', { type: 'contact_select', value: 'Max Mustermann' });
+    await formPage.fillField('followup', { type: 'select', value: 'Entsorgung' });
+
+    // Radio "Nicht relevant" waehlen → data_handling_ref ist optional
+    await formPage.fillField('data_handling', { type: 'radio', value: 'Nicht relevant' });
+
+    // Absenden OHNE data_handling_ref – sollte erfolgreich sein
+    await formPage.submit();
+
+    // Kein Fehler bei data_handling_ref erwartet
+    const refGroup = Selector('#data_handling_ref_group');
+    await t.expect(refGroup.hasClass('field-error')).notOk(
+        'data_handling_ref sollte keinen Fehler haben wenn data_handling = "Nicht relevant"'
+    );
+});
+
+// ── Konditionale Validierung: admin_access_cleanup / ticket_ref ──
+
+fixture`Validierung: admin-access-cleanup konditionale Felder`
+    .page`${BASE_URL}/forms/admin-access-cleanup`
+    .requestHooks(apiMocks);
+
+test('device_wiped unchecked → ticket_ref wird Pflichtfeld', async (t) => {
+    // Pflichtfelder ausfuellen
+    await formPage.fillField('asset_id', { type: 'text', value: 'ADM-VAL-001' });
+    await formPage.fillField('admin_user', { type: 'text', value: 'val@company.de' });
+    await formPage.fillField('account_removed', { type: 'checkbox' });
+    await formPage.fillField('keys_revoked', { type: 'checkbox' });
+
+    // device_wiped NICHT anklicken → ticket_ref wird Pflicht
+
+    // Absenden OHNE ticket_ref
+    await formPage.submit();
+
+    // Validierungsfehler fuer ticket_ref erwartet
+    const refGroup = Selector('#ticket_ref').parent('.field-group');
+    await t.expect(refGroup.hasClass('field-error')).ok(
+        'ticket_ref sollte Pflicht sein wenn device_wiped nicht gecheckt'
+    );
+});
+
+test('device_wiped checked → ticket_ref ist nicht Pflicht', async (t) => {
+    // Pflichtfelder ausfuellen
+    await formPage.fillField('asset_id', { type: 'text', value: 'ADM-VAL-002' });
+    await formPage.fillField('admin_user', { type: 'text', value: 'val@company.de' });
+    await formPage.fillField('account_removed', { type: 'checkbox' });
+    await formPage.fillField('keys_revoked', { type: 'checkbox' });
+
+    // device_wiped anklicken → ticket_ref ist optional
+    await formPage.fillField('device_wiped', { type: 'checkbox' });
+
+    // Absenden OHNE ticket_ref – sollte erfolgreich sein
+    await formPage.submit();
+
+    // Kein Fehler bei ticket_ref erwartet
+    const refGroup = Selector('#ticket_ref').parent('.field-group');
+    await t.expect(refGroup.hasClass('field-error')).notOk(
+        'ticket_ref sollte optional sein wenn device_wiped gecheckt'
+    );
+});
+
+// ── Checkbox-Validierung ──
+
+fixture`Validierung: Pflicht-Checkboxen`
+    .page`${BASE_URL}/forms/admin-user-commitment`
+    .requestHooks(apiMocks);
+
+test('Nicht angehakte Pflicht-Checkboxen erzeugen Fehler', async (t) => {
+    // Nur Text-/Datumsfelder ausfuellen, Checkboxen bewusst nicht anklicken
+    await formPage.fillField('asset_id', { type: 'text', value: 'ADM-VAL-003' });
+    await formPage.fillField('admin_user', { type: 'text', value: 'val@company.de' });
+
+    await formPage.submit();
+
+    // Mindestens die 5 Pflicht-Checkboxen muessen Fehler haben
+    const errorCheckboxes = Selector('.field-checkbox.field-error');
+    await t.expect(errorCheckboxes.count).gte(5, 'Alle 5 Pflicht-Checkboxen sollten Fehler haben');
+});


### PR DESCRIPTION
## Summary
This PR introduces a complete end-to-end test suite for the C5 Evidence Tool using TestCafe, covering form submission, validation, and conditional field logic across all 7 evidence forms.

## Key Changes

### Test Infrastructure
- **TestCafe setup**: Added `.testcaferc.js` configuration with appropriate timeouts and browser settings
- **Docker support**: Created `Dockerfile.testcafe` for containerized test execution and `docker-compose.e2e.yml` override for E2E environment
- **E2E configuration**: Added `config/c5_evidence.e2e.yaml` with Mailpit SMTP integration and all external services (Jira, NetBox) disabled for isolated testing

### Test Suites
- **01-index.test.js**: Tests for the landing page, verifying all 7 form cards are present and properly linked
- **02-form-submit.test.js**: Happy path tests for all 7 forms using fixture data, verifying successful submission and summary overlay display
- **03-validation.test.js**: Comprehensive validation tests including:
  - Required field validation (empty form submission)
  - Conditional field validation (e.g., `data_handling_ref` required only when `data_handling != "Nicht relevant"`)
  - Checkbox validation for mandatory fields

### Page Objects & Helpers
- **form.page.js**: Generic page object supporting all field types (text, date, select, checkbox, radio, contact_select) with methods for form filling, submission, and validation assertions
- **index.page.js**: Page object for landing page with selectors for form cards and track sections
- **api-mocks.js**: RequestMock configuration for mocking external API endpoints (contacts, tenants, asset-lookup) while allowing real backend submission flow

### Test Fixtures
Created JSON fixture files for all 7 forms with complete field definitions:
- `rz-provision.json`
- `rz-retire.json`
- `rz-owner-confirm.json`
- `admin-provision.json`
- `admin-user-commitment.json`
- `admin-return.json`
- `admin-access-cleanup.json`

### Build Integration
- Updated `Makefile` with `test-e2e` target for running the test suite
- Added E2E test directories to `.gitignore`

## Notable Implementation Details
- Tests use API mocks for external dependencies while testing the real backend submission flow with Mailpit
- Form filling is abstraction-based on field types, allowing reusable test logic across all forms
- Validation tests verify both positive cases (field becomes required) and negative cases (field remains optional)
- All tests include proper wait conditions and timeout handling for async operations

https://claude.ai/code/session_01TCgLJHPqZFKinXndcYVmcY